### PR TITLE
Ignore some hashes in Jest snapshot tests

### DIFF
--- a/infra/test/__snapshots__/java-stack.test.ts.snap
+++ b/infra/test/__snapshots__/java-stack.test.ts.snap
@@ -20,7 +20,7 @@ Object {
         ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-140966923789-eu-central-1",
-          "S3Key": "02eaccf2c7a5bca24a1360de04a6ec227dfbebb07d930a867f0fe8ee5fc32f4d.zip",
+          "S3Key": 64-byte-asset-hash-removed.zip,
         },
         "Description": "Blank Lambda template using Java",
         "FunctionName": "blank-java-template",
@@ -78,7 +78,7 @@ Object {
         ],
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-140966923789-eu-central-1",
-          "S3Key": "3f217f6e5142f6869799aabc18ef8ccee2483f40bb92ef335bb1381caf5e6260.zip",
+          "S3Key": 64-byte-asset-hash-removed.zip,
         },
         "Description": "Blank Lambda template using Java with Powertools",
         "Environment": Object {

--- a/infra/test/java-stack.test.ts
+++ b/infra/test/java-stack.test.ts
@@ -10,5 +10,19 @@ test('Java stack snapshot', () => {
   });
 
   const template = Template.fromStack(myStack);
+
+  // Replace all 64 byte asset hashes, because they are likely to tchange from build to build.
+  // For example 02eaccf2c7a5bca24a1360de04a6ec227dfbebb07d930a867f0fe8ee5fc32f4d.zip
+  expect.addSnapshotSerializer({
+    test: (val) => (typeof val === 'string' && val.match(/[0-9a-f]{64}.zip/) ? true : false),
+    print: (val) => {
+      if (typeof val === 'string') {
+        const newVal = val.replace(/[0-9a-f]{64}.zip/, '64-byte-asset-hash-removed.zip');
+        return newVal;
+      }
+      return `${val}`;
+    },
+  });
+
   expect(template).toMatchSnapshot();
 });

--- a/infra/test/java-stack.test.ts
+++ b/infra/test/java-stack.test.ts
@@ -17,8 +17,7 @@ test('Java stack snapshot', () => {
     test: (val) => (typeof val === 'string' && val.match(/[0-9a-f]{64}.zip/) ? true : false),
     print: (val) => {
       if (typeof val === 'string') {
-        const newVal = val.replace(/[0-9a-f]{64}.zip/, '64-byte-asset-hash-removed.zip');
-        return newVal;
+        return val.replace(/[0-9a-f]{64}.zip/, '64-byte-asset-hash-removed.zip');
       }
       return `${val}`;
     },


### PR DESCRIPTION
Ignore certain hashes in Jest snapshot tests, since these are likely to change after every build.

Fixes #45