### PR TITLE
Enable GHA in dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,14 @@ updates:
       time: "15:00"
       timezone: "Europe/Helsinki"
     open-pull-requests-limit: 10
+
+  # Enable version updates for GHA workflows
+  - package-ecosystem: "github-actions"
+    # Where to look for pom.xml files
+    directory: "/.github"
+    # Check updates every day (weekdays)
+    schedule:
+      interval: "daily"
+      time: "15:00"
+      timezone: "Europe/Helsinki"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
GitHub Actions workflows are now included in Dependabot checks.