### PR TITLE
Deps/infra: allow to be run with node18

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -5,8 +5,8 @@
     "infra": "bin/infra.js"
   },
   "engines": {
-    "node": ">20.0.0 <21.0.0",
-    "npm": ">=10.0.0"
+    "node": ">18.0.0 <21.0.0",
+    "npm": ">=8.0.0"
   },
   "scripts": {
     "all": "npx eslint . && npx prettier --check . && npm run test",


### PR DESCRIPTION
Re-enable node18 support since GitHub Dependabot still uses node18. The upgrade to node20 broke dependabot and it stopped to create dependency update PRs.