### PR TITLE
Testing AWS Lambda advanced logging

### DIFF
--- a/infra/lib/typescript-stack.ts
+++ b/infra/lib/typescript-stack.ts
@@ -26,6 +26,7 @@ export class TypescriptStack extends Stack {
       runtime: lambda.Runtime.NODEJS_20_X,
       memorySize: 512,
       timeout: Duration.seconds(15),
+      logFormat: lambda.LogFormat.TEXT,
     });
   }
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -14,7 +14,7 @@
     "clean": "npx rimraf '+(bin|lib|functions|test|utils)/**/+(*.d.ts|*.js)'",
     "watch": "tsc -w",
     "snap": "vitest",
-    "test": "npm run build && vitest run",
+    "test": "npm run build && vitest --no-threads run",
     "cdk": "npx cdk"
   },
   "devDependencies": {

--- a/infra/test/__snapshots__/typescript-stack.test.ts.snap
+++ b/infra/test/__snapshots__/typescript-stack.test.ts.snap
@@ -1,0 +1,108 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TypeScript stack snapshot 1`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "BlankTypescriptA74BC332": {
+      "DependsOn": [
+        "BlankTypescriptServiceRoleD38757B6",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": "cdk-hnb659fds-assets-140966923789-eu-central-1",
+          "S3Key": 64-byte-asset-hash-removed.zip,
+        },
+        "Description": "Blank Lambda template using Typescript",
+        "Environment": {
+          "Variables": {
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+          },
+        },
+        "FunctionName": "blank-typescript-template",
+        "Handler": "index.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "BlankTypescriptServiceRoleD38757B6",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Timeout": 15,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "BlankTypescriptServiceRoleD38757B6": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/infra/test/typescript-stack.test.ts
+++ b/infra/test/typescript-stack.test.ts
@@ -1,0 +1,29 @@
+import { Template } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
+import * as TS from '../lib/typescript-stack';
+import { expect, test } from 'vitest';
+
+test('TypeScript stack snapshot', () => {
+  const stack = new cdk.Stack();
+
+  const myStack = new TS.TypescriptStack(stack, 'MyTestStack', {
+    env: { account: '140966923789', region: 'eu-central-1' },
+    isUnitTest: true,
+  });
+
+  const template = Template.fromStack(myStack);
+
+  // Replace all 64 byte asset hashes, because they are likely to change from build to build.
+  // For example 02eaccf2c7a5bca24a1360de04a6ec227dfbebb07d930a867f0fe8ee5fc32f4d.zip
+  expect.addSnapshotSerializer({
+    test: (val) => (typeof val === 'string' && val.match(/[0-9a-f]{64}.zip/) ? true : false),
+    print: (val) => {
+      if (typeof val === 'string') {
+        return val.replace(/[0-9a-f]{64}.zip/, '64-byte-asset-hash-removed.zip');
+      }
+      return `${val}`;
+    },
+  });
+
+  expect(template).toMatchSnapshot();
+});


### PR DESCRIPTION
Now possible to

* define logging format
* define LogGroup
* define log level

https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/