### PR TITLE
Restore AWS Lambda connection reuse

### DIFF
--- a/infra/lib/typescript-stack.ts
+++ b/infra/lib/typescript-stack.ts
@@ -18,6 +18,7 @@ export class TypescriptStack extends Stack {
     super(scope, id, props);
 
     new nodejs.NodejsFunction(this, 'BlankTypescript', {
+      awsSdkConnectionReuse: true,
       entry: './typescript/blank-typescript/handler.ts',
       handler: 'handler',
       functionName: 'blank-typescript-template',

--- a/infra/test/__snapshots__/typescript-stack.test.ts.snap
+++ b/infra/test/__snapshots__/typescript-stack.test.ts.snap
@@ -23,6 +23,11 @@ exports[`TypeScript stack snapshot 1`] = `
           "S3Key": 64-byte-asset-hash-removed.zip,
         },
         "Description": "Blank Lambda template using Typescript",
+        "Environment": {
+          "Variables": {
+            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+          },
+        },
         "FunctionName": "blank-typescript-template",
         "Handler": "index.handler",
         "LoggingConfig": {


### PR DESCRIPTION
Restore connection reuse accidentally removed by CDK version update by explicitly setting the property.