### PR TITLE
Use JSON logging format for TS Lambda

### DIFF
--- a/infra/lib/typescript-stack.ts
+++ b/infra/lib/typescript-stack.ts
@@ -28,7 +28,9 @@ export class TypescriptStack extends Stack {
       runtime: lambda.Runtime.NODEJS_22_X,
       memorySize: LambdaMemory.QUARTER_VCPU,
       timeout: Duration.seconds(15),
-      loggingFormat: lambda.LoggingFormat.TEXT,
+      loggingFormat: lambda.LoggingFormat.JSON,
+      applicationLogLevelV2: lambda.ApplicationLogLevel.DEBUG,
+      systemLogLevelV2: lambda.SystemLogLevel.INFO,
     });
   }
 }

--- a/infra/test/__snapshots__/typescript-stack.test.ts.snap
+++ b/infra/test/__snapshots__/typescript-stack.test.ts.snap
@@ -31,7 +31,9 @@ exports[`TypeScript stack snapshot 1`] = `
         "FunctionName": "blank-typescript-template",
         "Handler": "index.handler",
         "LoggingConfig": {
-          "LogFormat": "Text",
+          "ApplicationLogLevel": "DEBUG",
+          "LogFormat": "JSON",
+          "SystemLogLevel": "INFO",
         },
         "MemorySize": 512,
         "Role": {

--- a/infra/typescript/blank-typescript/handler.ts
+++ b/infra/typescript/blank-typescript/handler.ts
@@ -5,14 +5,14 @@ export const handler: Handler = async (
   context: Context,
 ): Promise<APIGatewayProxyResult> => {
   const input = typeof event === 'string' ? event : JSON.stringify(event);
-  console.log(`Lambda input event: ${input}`);
-  console.log(`Lambda input context: ${JSON.stringify(context)}`);
+  console.debug(`Lambda input event: ${input}`);
+  console.debug(`Lambda input context: ${JSON.stringify(context)}`);
 
-  console.log(`Function ${context.functionName}:${context.functionVersion} handler was called`);
+  console.info(`Function ${context.functionName}:${context.functionVersion} handler was called`);
 
   // Print out environment variables
-  console.log('Environment variables:');
-  console.log(JSON.stringify(process.env, null, 2));
+  console.debug('Environment variables:');
+  console.debug(JSON.stringify(process.env, null, 2));
 
   return {
     statusCode: 200,


### PR DESCRIPTION
- Use JSON logging format.
- Define application and system log levels.